### PR TITLE
Remove ref to dead nymservers

### DIFF
--- a/conf/dest.alw
+++ b/conf/dest.alw
@@ -20,17 +20,11 @@
 ## nymservers
 ##
 /@nym\.mixmin\.net$/
-/@mixnym\.net$/
-/@is-not-my\.name$/
 /@nymph\.paranoici\.org$/
-/@nymphet\.paranoici\.org$/
-/@nym\.now\.im$/
-
 
 ##
 ## Some (not all) pingers
 ##
-/^echolot(?:1024)?[+@]/
+/^echolot[+@]/
 /^pinger[+@]/
-/^estragon(?:\+[^@]+)?@frell\.theremailer\.net$/
-/^echolot4\+/
+/^estragon[+@].*?frell\.theremailer\.net$/


### PR DESCRIPTION
With the passage of time some nymservers no longer exist. My changes to the file dest.alw involves removing references to those dead nymservers. Also, I did the same with any references to dead pinger addresses. Like echolot1024@ for example.